### PR TITLE
Created Administrator and Customer roles

### DIFF
--- a/Areas/Identity/Pages/Account/Register.cshtml
+++ b/Areas/Identity/Pages/Account/Register.cshtml
@@ -18,6 +18,11 @@
                 <span asp-validation-for="Input.UserName" class="text-danger"></span>
             </div>
             <div class="form-group">
+                <label asp-for="Input.Email"></label>
+                <input asp-for="Input.Email" class="form-control" />
+                <span asp-validation-for="Input.Email" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <label asp-for="Input.Password"></label>
                 <input asp-for="Input.Password" class="form-control" />
                 <span asp-validation-for="Input.Password" class="text-danger"></span>

--- a/Models/IdentityHelper.cs
+++ b/Models/IdentityHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,6 +16,30 @@ namespace MouseHouse.Models
 {
     public class IdentityHelper
     {
+        // Roles
+        public const string Administrator = "administrator";
+        public const string Customer = "customer";
+
+        /// <summary>
+        /// Creates roles if they are passed in as strings
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="roles"></param>
+        /// <returns></returns>
+        public static async Task CreateRoles(IServiceProvider provider, params string[] roles)
+        {
+            RoleManager<IdentityRole> roleManager = provider.GetRequiredService<RoleManager<IdentityRole>>();
+
+            foreach (string role in roles)
+            {
+                bool doesRoleExist = await roleManager.RoleExistsAsync(role);
+                if (!doesRoleExist)
+                {
+                    await roleManager.CreateAsync(new IdentityRole(role));
+                }
+            }
+        }
+
         /// <summary>
         /// Sets Identity options for sign in procedures, passwords, and lockout options:
         /// Sign in options don't require a confirmed email or phone number.

--- a/Models/IdentityHelper.cs
+++ b/Models/IdentityHelper.cs
@@ -41,6 +41,33 @@ namespace MouseHouse.Models
         }
 
         /// <summary>
+        /// Creates a default administator account with an username, email, and password. 
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <returns></returns>
+        public static async Task CreateDefaultAdministrator(IServiceProvider provider)
+        {
+            const string email = "administrator@mousehouse.com";
+            const string username = "administrator";
+            const string password = "password";
+
+            var userManager = provider.GetRequiredService<UserManager<IdentityUser>>();
+
+            if (userManager.Users.Count() == 0)
+            {
+                IdentityUser administrator = new IdentityUser()
+                {
+                    Email = email,
+                    UserName = username
+                };
+
+                // creating the administrator
+                await userManager.CreateAsync(administrator, password);
+                await userManager.AddToRoleAsync(administrator, Administrator);
+            }
+        }
+
+        /// <summary>
         /// Sets Identity options for sign in procedures, passwords, and lockout options:
         /// Sign in options don't require a confirmed email or phone number.
         /// Password strength requirement is only 8 characters, no required uppercase/lowercase/digits/special characters.

--- a/Startup.cs
+++ b/Startup.cs
@@ -32,6 +32,7 @@ namespace MouseHouse
                 options.UseSqlServer(
                     Configuration.GetConnectionString("DefaultConnection")));
             services.AddDefaultIdentity<IdentityUser>(IdentityHelper.SetIdentityOptions)
+                .AddRoles<IdentityRole>()
                 .AddEntityFrameworkStores<ApplicationDbContext>();
             services.AddControllersWithViews();
             services.AddRazorPages();
@@ -91,6 +92,15 @@ namespace MouseHouse
                     pattern: "{controller=Home}/{action=Index}/{id?}");
                 endpoints.MapRazorPages();
             });
+
+            // creating roles
+            // create roles
+            IServiceScope serviceProvider = app.ApplicationServices
+                                               .GetRequiredService<IServiceProvider>()
+                                               .CreateScope();
+            IdentityHelper.CreateRoles(serviceProvider.ServiceProvider,
+                                       IdentityHelper.Administrator,
+                                       IdentityHelper.Customer).Wait();
         }
     }
 }

--- a/Startup.cs
+++ b/Startup.cs
@@ -94,13 +94,14 @@ namespace MouseHouse
             });
 
             // creating roles
-            // create roles
             IServiceScope serviceProvider = app.ApplicationServices
                                                .GetRequiredService<IServiceProvider>()
                                                .CreateScope();
             IdentityHelper.CreateRoles(serviceProvider.ServiceProvider,
                                        IdentityHelper.Administrator,
                                        IdentityHelper.Customer).Wait();
+            // create the default administrator
+            IdentityHelper.CreateDefaultAdministrator(serviceProvider.ServiceProvider).Wait();
         }
     }
 }


### PR DESCRIPTION
Administrator and Customer roles were created in the IdentityHelper class and managed with two new methods, CreateRoles and CreateDefaultAdministrator. Closes #1

CreateDefaultAdminstrator creates a user account with the Administrator role, complete with a username, email, and password on Startup. Closes #6 

While testing the registration process, a mistake where there was no email input on the Register page was noticed and then fixed. Closes #16  