### PR TITLE
Assigning roles on registration according to email

### DIFF
--- a/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -13,12 +13,19 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
+using MouseHouse.Models;
 
 namespace MouseHouse.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
     public class RegisterModel : PageModel
     {
+        /*
+         * Users registering with this email address 
+         * will be assigned the Administrator role
+         */
+        private const string AdminEmail = "@mousehouse.com";
+
         private readonly SignInManager<IdentityUser> _signInManager;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly ILogger<RegisterModel> _logger;
@@ -84,6 +91,25 @@ namespace MouseHouse.Areas.Identity.Pages.Account
                 if (result.Succeeded)
                 {
                     _logger.LogInformation("User created a new account with password.");
+
+                    // Assigning roles here
+                    if (user.Email.ToLower().EndsWith(AdminEmail))
+                    {
+                        var roleResult = await _userManager.AddToRoleAsync(user, IdentityHelper.Administrator);
+                        if (!roleResult.Succeeded)
+                        {
+                            _logger.LogInformation($"{user.UserName} not added to {IdentityHelper.Administrator} role");
+                        }
+                    }
+                    else
+                    {
+                        var roleResult = await _userManager.AddToRoleAsync(user, IdentityHelper.Customer);
+                        if (!roleResult.Succeeded)
+                        {
+                            _logger.LogInformation($"{user.UserName} not added to {IdentityHelper.Customer} role");
+                        }
+                    }
+                    //
 
                     var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                     code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));


### PR DESCRIPTION
Closes #7 
Users registering with email addresses ending with "@mousehouse.com" will be assigned the Admin role. Otherwise, they will be assigned as a Customer. 