### PR TITLE
Orders Total as 0.00 in database bug

### DIFF
--- a/Controllers/CheckoutController.cs
+++ b/Controllers/CheckoutController.cs
@@ -43,13 +43,26 @@ namespace MouseHouse.Controllers
             _context.SaveChanges();
 
             CartCookieHelper.EmptyCart(_httpContext);
-            return Redirect("Complete");
+            return RedirectToAction("Complete",
+                new { id = order.OrderNumber});
         }
 
         // GET: Checkout/Complete
-        public IActionResult Complete()
+        public IActionResult Complete(int id)
         {
-            return View();
+            // validate customer owns this order
+            bool isValid = _context.Orders.Any(
+                o => o.OrderNumber == id &&
+                o.Username == User.Identity.Name);
+
+            if (isValid)
+            {
+                return View(id);
+            }
+            else
+            {
+                return View("Error");
+            }
         }
     }
 }

--- a/Controllers/CheckoutController.cs
+++ b/Controllers/CheckoutController.cs
@@ -36,6 +36,8 @@ namespace MouseHouse.Controllers
 
             order.Username = User.Identity.Name;
             order.OrderDate = DateTime.Now;
+            order.Total = (decimal)CartCookieHelper.GetCartTotal(_httpContext);
+
 
             _context.Orders.Add(order);
             _context.SaveChanges();

--- a/Views/Checkout/Complete.cshtml
+++ b/Views/Checkout/Complete.cshtml
@@ -1,4 +1,4 @@
-﻿@model MouseHouse.Models.Order
+﻿@model int
 
 @{
     ViewData["Title"] = "Complete";
@@ -7,3 +7,4 @@
 
 <h1>Completed Checkout</h1>
 <p>Thank you for your purchase!</p>
+<p>Your OrderID is: @Model <p>


### PR DESCRIPTION
Closes #37
The bug where Orders added to the database would have the total 0.00 is fixed. Now when orders are added to the database via the CheckoutController, the correct total is added. I used the CartCookieHelper method GetCartTotal and converted the total to a decimal. 

I also had it so that the order's number displays on the Complete view after a purchase. 
![image](https://user-images.githubusercontent.com/63821532/111088751-ee943680-84e5-11eb-8641-f7ff53ecc4e1.png)
