### PR TITLE
Refactored Cart Summary view

### DIFF
--- a/Models/CartCookieHelper.cs
+++ b/Models/CartCookieHelper.cs
@@ -100,6 +100,26 @@ namespace MouseHouse
             // return the total
             return total;
         }
+
+        /// <summary>
+        /// Returns true if cart is empty
+        /// </summary>
+        /// <param name="http"></param>
+        /// <returns></returns>
+        public static bool IsCartEmpty(IHttpContextAccessor http)
+        {
+            // get all products from cart
+            List<Product> cartProducts = GetCartProducts(http);
+            // if the cart has a count of 0 products, return true
+            if (cartProducts.Count == 0)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
     }
 }
 

--- a/Views/Cart/Summary.cshtml
+++ b/Views/Cart/Summary.cshtml
@@ -7,7 +7,7 @@
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
-<h1>Summary</h1>
+<h1>Your Cart</h1>
 
 @{
     string prevUrl = http.HttpContext.Request.Path;

--- a/Views/Cart/Summary.cshtml
+++ b/Views/Cart/Summary.cshtml
@@ -4,90 +4,35 @@
 
 @{
     ViewData["Title"] = "Summary";
+    Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
 <h1>Summary</h1>
-<table class="table">
-    <thead>
-        <tr>
-            <th>
-                @Html.DisplayNameFor(model => model.Title)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Price)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Category)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Department)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.ImageUrl)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Weight)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Height)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Length)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Width)
-            </th>
-            <th>
-                @Html.DisplayNameFor(model => model.Color)
-            </th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-        @{
-            string prevUrl = http.HttpContext.Request.Path;
-        }
-        @foreach (var item in Model)
-        {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.Title)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Price)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Category)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Department)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.ImageUrl)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Weight)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Height)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Length)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Width)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Color)
-            </td>
-            <td>
-                <a class="btn btn-danger" asp-route-id="@item.ProductId" asp-route-prevUrl="@prevUrl" asp-controller="Cart" asp-action="Delete">Remove</a>
-            </td>
-        </tr>
-        }
-    </tbody>
-    <a class="btn btn-danger" asp-route-prevUrl="@prevUrl" asp-controller="Cart" asp-action="ClearCart">Empty Cart</a>
-</table>
+
+@{
+    string prevUrl = http.HttpContext.Request.Path;
+}
+<a class="btn btn-danger" asp-route-prevUrl="@prevUrl" asp-controller="Cart" asp-action="ClearCart">Empty Cart</a>
+@foreach (var item in Model)
+{
+    <div class="row-body">
+        <p class="row-price">@Html.DisplayFor(modelItem => item.Price)</p>
+        <div class="row-image">
+            @{
+                string ImagePath = item.ImageUrl;
+            }
+            <img class="row-image" src="~/@ImagePath">
+        </div>
+        <h5 class="row-title">@Html.DisplayFor(modelItem => item.Title)</h5>
+        <p class="row-text">@Html.DisplayFor(modelItem => item.Category)</p>
+
+        <a asp-route-id="@item.ProductId" asp-route-prevUrl="@prevUrl" asp-controller="Cart" asp-action="Delete">Remove from Cart</a>
+    </div>
+}
+
+
+
+
 <div>
     <h4>Total: $@Math.Round(CartCookieHelper.GetCartTotal(http), 2)</h4>
     <a class="btn btn-primary"

--- a/Views/Cart/Summary.cshtml
+++ b/Views/Cart/Summary.cshtml
@@ -12,7 +12,7 @@
 @{
     string prevUrl = http.HttpContext.Request.Path;
 }
-<a class="btn btn-danger" asp-route-prevUrl="@prevUrl" asp-controller="Cart" asp-action="ClearCart">Empty Cart</a>
+
 @foreach (var item in Model)
 {
     <div class="row-body">
@@ -31,8 +31,8 @@
 }
 
 
-
-
+ @if (!CartCookieHelper.IsCartEmpty(http))
+ {
 <div>
     <h4>Total: $@Math.Round(CartCookieHelper.GetCartTotal(http), 2)</h4>
     <a class="btn btn-primary"
@@ -40,4 +40,12 @@
        asp-action="AddressAndPayment">
         Proceed to Checkout
     </a>
+    <a class="btn btn-danger" asp-route-prevUrl="@prevUrl" asp-controller="Cart" asp-action="ClearCart">Empty Cart</a>
 </div>
+ }
+ else
+ {
+     <h4>Your cart is empty!</h4>
+     <a asp-action="Index" asp-controller="Catalog">Let's go fix that.</a>
+ }
+

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -11,6 +11,8 @@
     <link rel="stylesheet" href="~/css/Cards.css" />
     <!-- Custom CSS file for Sorting Section displayed on Catalog page -->
     <link rel="stylesheet" href="~/css/SortingMenu.css" />
+    <!-- Custom CSS file for Summary view for CartController -->
+    <link rel="stylesheet" href="~/css/CartSummary.css" />
 
 </head>
 <body>

--- a/wwwroot/css/CartSummary.css
+++ b/wwwroot/css/CartSummary.css
@@ -43,6 +43,6 @@
     font-weight: bold;
 }
 
-.btn {
-    color: lightgray;
+.row-body > a {
+    color: #9c9c9c;
 }

--- a/wwwroot/css/CartSummary.css
+++ b/wwwroot/css/CartSummary.css
@@ -1,0 +1,48 @@
+﻿
+.row-image > img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.row-body > .row-image {
+    width: 20%;
+    height: auto;
+    padding: 2em 4em 2em 1em;
+    float: left;
+}
+
+.row-body {
+    border-bottom: solid rgb(211, 211, 211) 1px;
+    transition: 0.3s;
+    width: 70%;
+    border-radius: 2px;
+    margin: 2%;
+    padding: 2em;
+}
+
+.row-title {
+    font-size: large;
+    font-weight: bold;
+    margin-bottom: 0.5em;
+}
+
+.row-text {
+    font-size: medium;
+    font-weight: bold;
+    margin-top: 0.5em;
+    color: rgb(112, 112, 112);
+}
+
+.row-price {
+    float: right;
+    position: relative;
+    margin-top: 1em;
+    margin-right: 2em;
+    font-size: xx-large;
+    font-weight: bold;
+}
+
+.btn {
+    color: lightgray;
+}


### PR DESCRIPTION
Closes #62 
![image](https://user-images.githubusercontent.com/63821532/111110334-96772780-8519-11eb-977b-38e929623593.png)
Products in the cart are now displayed in stylish rows with their image. 

Additionally, the checkout/empty cart buttons are not displayed when the cart is empty. Instead there is a link to the Catalog view.
![image](https://user-images.githubusercontent.com/63821532/111110498-e2c26780-8519-11eb-97cf-dae0fe39ebda.png)
