### PR TITLE
Clear button on Catalog's sorting/filtering menu

### DIFF
--- a/Views/Catalog/Index.cshtml
+++ b/Views/Catalog/Index.cshtml
@@ -134,6 +134,14 @@
                 </li>
             </ul>
         </li>
+
+        <!-- Resets all options/filters applied to view (shows default page)-->
+        <li class="option">
+            <a asp-action="Index"
+               asp-route-colorString=@String.Empty
+               asp-route-sortOrder=@String.Empty
+               class="btn btn-light btn-option">Clear</a>
+        </li>
     </ul>
 </div>
 


### PR DESCRIPTION
Closes #66 
There is now a "Clear" button at the end of the sorting/filtering menu on the Catalog view. It removes any applied sorting/filtering method currently on the page.